### PR TITLE
_buttonReact() can't handle multiple buttons at once

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+
 import 'package:xinput_gamepad/xinput_gamepad.dart';
 
 void main(List<String> arguments) {
@@ -75,6 +76,6 @@ void main(List<String> arguments) {
   }
 
   for (Controller controller in availableControllers) {
-    controller.lister();
+    controller.listen();
   }
 }

--- a/examples/console/bin/main.dart
+++ b/examples/console/bin/main.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+
 import 'package:xinput_gamepad/xinput_gamepad.dart';
 
 void main(List<String> arguments) {
@@ -75,6 +76,6 @@ void main(List<String> arguments) {
   }
 
   for (Controller controller in availableControllers) {
-    controller.lister();
+    controller.listen();
   }
 }

--- a/examples/flutter_windows/lib/pages/widgets/controller_information_containter.dart
+++ b/examples/flutter_windows/lib/pages/widgets/controller_information_containter.dart
@@ -229,7 +229,7 @@ class _ControllerInformationContainterState
       }
     };
 
-    controller.lister();
+    controller.listen();
     super.initState();
   }
 

--- a/lib/src/gamepad/controller.dart
+++ b/lib/src/gamepad/controller.dart
@@ -178,31 +178,36 @@ class Controller {
     }, cancelOnError: false);
   }
 
-  ControllerButton? _lastButtonPressed;
+  int? _lastButtonsBitmask;
   void _buttonsReact() {
-    final ControllerButton? button =
-        InputBitmaskConverter.convertButton(_lastGamepadValidState.wButtons);
+    int buttonBitmask = _lastGamepadValidState.wButtons;
+    final List<ControllerButton>? buttons =
+        InputBitmaskConverter.convertButton(buttonBitmask);
 
     buttonsMapping?.forEach((mapedButtons, action) {
       //The button pressed is different than last.
       //This means the button has been released.
-      if (_lastButtonPressed != null && button != _lastButtonPressed) {
-        onReleaseButton?.call(_lastButtonPressed!);
-        _lastButtonPressed = null;
+      if (_lastButtonsBitmask != null && buttonBitmask < _lastButtonsBitmask!) {
+        ControllerButton releasedButton =
+            InputBitmaskConverter.convertButton(_lastButtonsBitmask!)!.first;
+        onReleaseButton?.call(releasedButton);
+        _lastButtonsBitmask = null;
       }
 
       switch (buttonMode) {
         case ButtonMode.PRESS:
           //When the the current state's button is diferent than last.
-          if (_lastButtonPressed == null && button == mapedButtons) {
-            _lastButtonPressed = button;
+          if (_lastButtonsBitmask == null &&
+              buttons != null &&
+              buttons.contains(mapedButtons)) {
+            _lastButtonsBitmask = buttonBitmask;
             action();
           }
           break;
         case ButtonMode.HOLD:
           //No matter if the last state's button is the same than this.
-          if (button == mapedButtons) {
-            _lastButtonPressed = button;
+          if (buttons != null && buttons.contains(mapedButtons)) {
+            _lastButtonsBitmask = buttonBitmask;
             action();
           }
           break;

--- a/lib/src/gamepad/controller.dart
+++ b/lib/src/gamepad/controller.dart
@@ -109,6 +109,7 @@ class Controller {
   ///controller.onReleaseButton = (button) => print("$button has ben released");
   ///```
   Function(ControllerButton button)? onReleaseButton;
+  Function(int bitmask)? onRawButtonEvent;
 
   //Vibration
   //Available range: 0-65535
@@ -140,6 +141,7 @@ class Controller {
       this.variableKeysMapping,
       this.variantsVariableKeyMapping,
       this.onReleaseButton,
+      this.onRawButtonEvent,
       this.buttonMode = ButtonMode.PRESS,
       this.leftVibrationSpeed = 16000,
       this.rightVibrationSpeed = 16000,
@@ -163,7 +165,11 @@ class Controller {
       _dwPacketNumber = event.ref.dwPacketNumber;
       _lastGamepadValidState = event.ref.Gamepad;
 
-      _buttonsReact();
+      if (onRawButtonEvent != null) {
+        onRawButtonEvent?.call(_lastGamepadValidState.wButtons);
+      } else {
+        _buttonsReact();
+      }
       _thumbsTriggersReact();
 
       free(event);

--- a/lib/src/gamepad/controller.dart
+++ b/lib/src/gamepad/controller.dart
@@ -1,12 +1,12 @@
 import 'dart:async';
 import 'dart:ffi';
-import 'package:win32/win32.dart';
-import 'package:ffi/ffi.dart';
 import 'dart:math';
+
+import 'package:win32/win32.dart';
 import 'package:xinput_gamepad/src/models/controller_battery.dart';
 import 'package:xinput_gamepad/src/models/controller_capabilities.dart';
-import 'package:xinput_gamepad/src/utils/controller_utils.dart';
 import 'package:xinput_gamepad/src/utils/bitmask_converters/input_bitmask_converter.dart';
+import 'package:xinput_gamepad/src/utils/controller_utils.dart';
 import 'package:xinput_gamepad/xinput_gamepad.dart';
 
 ///Used to simulate events using a XInput controller.
@@ -155,9 +155,9 @@ class Controller {
   StreamSubscription? _controllerListenerSubscription;
 
   ///Start to listen inputs from the controller.
-  void lister() async {
+  void listen() async {
     final controllerStateStream = ControllerUtils.streamState(index)
-    .where((event) => _dwPacketNumber != event.ref.dwPacketNumber);
+        .where((event) => _dwPacketNumber != event.ref.dwPacketNumber);
 
     _controllerListenerSubscription = controllerStateStream.listen((event) {
       _dwPacketNumber = event.ref.dwPacketNumber;
@@ -169,8 +169,7 @@ class Controller {
       free(event);
     }, onError: (error) {
       print("A error occurs: $error");
-    }, 
-    cancelOnError: false);
+    }, cancelOnError: false);
   }
 
   ControllerButton? _lastButtonPressed;

--- a/lib/src/utils/bitmask_converters/input_bitmask_converter.dart
+++ b/lib/src/utils/bitmask_converters/input_bitmask_converter.dart
@@ -2,56 +2,52 @@ import 'package:win32/win32.dart';
 import 'package:xinput_gamepad/src/enums/controller_button.dart';
 
 class InputBitmaskConverter {
-  static ControllerButton? convertButton(int bitmask) {
-    ControllerButton? button;
+  static List<ControllerButton>? convertButton(int bitmask) {
+    List<ControllerButton>? buttons = List.empty(growable: true);
 
-    switch (bitmask) {
-      case XINPUT_GAMEPAD_DPAD_UP:
-        button = ControllerButton.DPAD_UP;
-        break;
-      case XINPUT_GAMEPAD_DPAD_DOWN:
-        button = ControllerButton.DPAD_DOWN;
-        break;
-      case XINPUT_GAMEPAD_DPAD_LEFT:
-        button = ControllerButton.DPAD_LEFT;
-        break;
-      case XINPUT_GAMEPAD_DPAD_RIGHT:
-        button = ControllerButton.DPAD_RIGHT;
-        break;
-      case XINPUT_GAMEPAD_START:
-        button = ControllerButton.START;
-        break;
-      case XINPUT_GAMEPAD_BACK:
-        button = ControllerButton.BACK;
-        break;
-      case XINPUT_GAMEPAD_LEFT_THUMB:
-        button = ControllerButton.LEFT_THUMB;
-        break;
-      case XINPUT_GAMEPAD_RIGHT_THUMB:
-        button = ControllerButton.RIGHT_THUMB;
-        break;
-      case XINPUT_GAMEPAD_LEFT_SHOULDER:
-        button = ControllerButton.LEFT_SHOULDER;
-        break;
-      case XINPUT_GAMEPAD_RIGHT_SHOULDER:
-        button = ControllerButton.RIGHT_SHOULDER;
-        break;
-      case XINPUT_GAMEPAD_A:
-        button = ControllerButton.A_BUTTON;
-        break;
-      case XINPUT_GAMEPAD_B:
-        button = ControllerButton.B_BUTTON;
-        break;
-      case XINPUT_GAMEPAD_X:
-        button = ControllerButton.X_BUTTON;
-        break;
-      case XINPUT_GAMEPAD_Y:
-        button = ControllerButton.Y_BUTTON;
-        break;
-      default:
-        button = null;
+    if (bitmask & XINPUT_GAMEPAD_DPAD_UP > 0) {
+      buttons.add(ControllerButton.DPAD_UP);
+    }
+    if (bitmask & XINPUT_GAMEPAD_DPAD_DOWN > 0) {
+      buttons.add(ControllerButton.DPAD_DOWN);
+    }
+    if (bitmask & XINPUT_GAMEPAD_DPAD_LEFT > 0) {
+      buttons.add(ControllerButton.DPAD_LEFT);
+    }
+    if (bitmask & XINPUT_GAMEPAD_DPAD_RIGHT > 0) {
+      buttons.add(ControllerButton.DPAD_RIGHT);
+    }
+    if (bitmask & XINPUT_GAMEPAD_START > 0) {
+      buttons.add(ControllerButton.START);
+    }
+    if (bitmask & XINPUT_GAMEPAD_BACK > 0) {
+      buttons.add(ControllerButton.BACK);
+    }
+    if (bitmask & XINPUT_GAMEPAD_LEFT_THUMB > 0) {
+      buttons.add(ControllerButton.LEFT_THUMB);
+    }
+    if (bitmask & XINPUT_GAMEPAD_RIGHT_THUMB > 0) {
+      buttons.add(ControllerButton.RIGHT_THUMB);
+    }
+    if (bitmask & XINPUT_GAMEPAD_LEFT_SHOULDER > 0) {
+      buttons.add(ControllerButton.LEFT_SHOULDER);
+    }
+    if (bitmask & XINPUT_GAMEPAD_RIGHT_SHOULDER > 0) {
+      buttons.add(ControllerButton.RIGHT_SHOULDER);
+    }
+    if (bitmask & XINPUT_GAMEPAD_A > 0) {
+      buttons.add(ControllerButton.A_BUTTON);
+    }
+    if (bitmask & XINPUT_GAMEPAD_B > 0) {
+      buttons.add(ControllerButton.B_BUTTON);
+    }
+    if (bitmask & XINPUT_GAMEPAD_X > 0) {
+      buttons.add(ControllerButton.X_BUTTON);
+    }
+    if (bitmask & XINPUT_GAMEPAD_Y > 0) {
+      buttons.add(ControllerButton.Y_BUTTON);
     }
 
-    return button;
+    return buttons.isNotEmpty ? buttons : null;
   }
 }


### PR DESCRIPTION
For example, when I push "fire" button while "moving", xinput returns bitmask  like (XINPUT_GAMEPAD_DPAD_UP | XINPUT_GAMEPAD_A), and InputBitmaskConverter.convertButton return null. 

In my case the easiest way was to bring access to raw bitmask and work with it an "old-shcool way": 

 ```dart
 onRawButtonEvent(int bitmask) {
    useController = true;
    keysPressed.clear();
    if (bitmask & XINPUT_GAMEPAD_DPAD_UP > 0) {
      keysPressed.add(LogicalKeyboardKey.keyW);
    } else if (bitmask & XINPUT_GAMEPAD_DPAD_DOWN > 0) {
      keysPressed.add(LogicalKeyboardKey.keyS);
    } else if (bitmask & XINPUT_GAMEPAD_DPAD_LEFT > 0) {
      keysPressed.add(LogicalKeyboardKey.keyA);
    } else if (bitmask & XINPUT_GAMEPAD_DPAD_RIGHT > 0) {
      keysPressed.add(LogicalKeyboardKey.keyD);
    }

    if (bitmask & (XINPUT_GAMEPAD_X | XINPUT_GAMEPAD_RIGHT_SHOULDER) > 0) {
      keysPressed.add(LogicalKeyboardKey.space);
      spaceHold = true;
    } else {
      spaceHold = false;
    }
    if (bitmask & XINPUT_GAMEPAD_BACK > 0) {
      keysPressed.add(LogicalKeyboardKey.escape);
    }
    if (bitmask & XINPUT_GAMEPAD_START > 0) {
      keysPressed.add(LogicalKeyboardKey.backquote);
    }
    if (keysPressed.isNotEmpty) {
      notifyListeners();
    }
  }
```

With bitmask I can handle each button both individually and in combinations. I thing, this functionality should exists while more modern solution is not implemented. 